### PR TITLE
Fix ssh service launch

### DIFF
--- a/hadoop-master/bootstrap.sh
+++ b/hadoop-master/bootstrap.sh
@@ -14,7 +14,7 @@ cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; 
 #sed s/NAMENODE/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/hdfs-site.xml.template > /usr/local/hadoop/etc/hadoop/hdfs-site.xml
 #sed s/RESOURCEMANAGER/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/yarn-site.xml.template.template > /usr/local/hadoop/etc/hadoop/yarn-site.xml.template
 
-service sshd start
+service ssh start
 nohup $HADOOP_PREFIX/bin/hdfs namenode &
 nohup $HADOOP_PREFIX/bin/yarn resourcemanager &
 nohup $HADOOP_PREFIX/bin/yarn timelineserver &

--- a/hadoop-slave/bootstrap.sh
+++ b/hadoop-slave/bootstrap.sh
@@ -14,7 +14,7 @@ cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; 
 #sed s/NAMENODE/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/hdfs-site.xml.template > /usr/local/hadoop/etc/hadoop/hdfs-site.xml
 #sed s/RESOURCEMANAGER/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/yarn-site.xml.template.template > /usr/local/hadoop/etc/hadoop/yarn-site.xml.template
 
-service sshd start
+service ssh start
 nohup $HADOOP_PREFIX/bin/hdfs datanode 2>> /var/log/hadoop/datanode.err >> /var/log/hadoop/datanode.out &
 nohup $HADOOP_PREFIX/bin/yarn nodemanager 2>> /var/log/hadoop/nodemanager.err >> /var/log/hadoop/nodemanager.out &
 


### PR DESCRIPTION
Both `hadoop-master` and `hadoop-slave` containers fail to launch `sshd` due to a typo in `bootstrap.sh` script.

Following error is logged:
```log
sshd: unrecognized service
```
It should be called `service ssh start` instead of `service sshd start`