### PR TITLE
Set default Erasure Coding policy

### DIFF
--- a/hadoop-base/hdfs-site.xml
+++ b/hadoop-base/hdfs-site.xml
@@ -3,4 +3,8 @@
         <name>dfs.replication</name>
         <value>3</value>
     </property>
+    <property>
+        <name>dfs.namenode.ec.policies.enabled</name>
+        <value>RS-3-2-64k</value>
+    </property>
 </configuration>


### PR DESCRIPTION
Hadoop-3.0 supports for [Erasure Coding](https://hadoop.apache.org/docs/r3.0.0-alpha2/hadoop-project-dist/hadoop-hdfs/HDFSErasureCoding.html) in HDFS.

HDFS does not enable any erasure coding policies by default (please see [HDFS-11505](https://issues.apache.org/jira/browse/HDFS-11505)). If we want to create ec files, we need to add the policies to `dfs.namenode.ec.policies.enabled`. Since docker-hadoop-cluster has five datanode, `RS-3-2-64k` would be suitable as the default policy.